### PR TITLE
Small improvements improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,53 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "*" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install alsa and udev
+      run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+    - name: Build
+      run: cargo build --all-features --release --verbose
+      
+  test:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create folder
+      run: mkdir -p assets/voxel_data/
+    - name: Install alsa and udev
+      run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+    - name: tests
+      run: cargo test --all-features -- --nocapture
+  
+  fmt:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: FMT
+      run: cargo fmt -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install alsa and udev
+      run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+    - name: install-clippy
+      run: rustup component add clippy
+    - name: clippy
+      run: cargo clippy --all-features -- -W clippy::all -W clippy::nursery --deny "warnings"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install alsa and udev
       run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
     - name: tests
-      run: cargo test --all-features -- --nocapture
+      run: cargo test
   
   fmt:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ repository = "https://github.com/DoubleHyphen/lindel"
 all-features = true
 
 [dependencies]
-num = {version = "0.2"}
-num-traits = {version = "0.2"}
+num = "0.4"
+num-traits = "0.2"
 nalgebra = {version = "0.25", optional = true}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindel"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["froderick <velona@ahiru.eu>"]
 edition = "2018"
 description = "A crate for Hilbert and Morton encoding and decoding; in a word, linearising and delinearising."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ nalgebra = {version = "0.25", optional = true}
 
 [dev-dependencies]
 rand = "0.8"
+criterion = "0.4"
 
 [dependencies.morton-encoding]
 version = "^2"
@@ -33,3 +34,8 @@ default-features = false
 default = ["std"]
 std = []
 nalg = ["nalgebra"]
+
+
+[[bench]]
+name = "metrics"
+harness = false

--- a/benches/metrics.rs
+++ b/benches/metrics.rs
@@ -1,0 +1,29 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use lindel::*;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("hilbert_decode", |b| {
+        b.iter(|| {
+            let _: [u32; 3] = hilbert_decode(34589430);
+        })
+    });
+    c.bench_function("hilbert_encode", |b| {
+        b.iter(|| {
+            let _: u128 = hilbert_encode([43u32, 12, 32]);
+        })
+    });
+
+    c.bench_function("morton_decode", |b| {
+        b.iter(|| {
+            let _: [u32; 3] = morton_decode(34589430);
+        })
+    });
+    c.bench_function("morton_encode", |b| {
+        b.iter(|| {
+            let _: u128 = morton_encode([43u32, 12, 32]);
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/compact_encoding.rs
+++ b/src/compact_encoding.rs
@@ -2,24 +2,24 @@
 //! Chris Hamilton, and (in the near future) of Compact Z-indices by the crate maintainer.
 
 /// Right rotation of x by b bits out of n.
-fn rotate_right(x: usize, b: u32, n: u32) -> usize {
+const fn rotate_right(x: usize, b: u32, n: u32) -> usize {
     let l = x & ((1 << b) - 1);
     let r = x >> b;
     (l << (n - b)) | r
 }
 
 /// Left rotation of x by b bits out of n.
-fn rotate_left(x: usize, b: u32, n: u32) -> usize {
+const fn rotate_left(x: usize, b: u32, n: u32) -> usize {
     rotate_right(x, n - b, n)
 }
 
 /// Binary reflected Gray code.
-fn gray_code(i: usize) -> usize {
+const fn gray_code(i: usize) -> usize {
     i ^ (i >> 1)
 }
 
 /// e(i), the entry point for the ith sub-hypercube.
-fn entry_point(i: usize) -> usize {
+const fn entry_point(i: usize) -> usize {
     if i == 0 {
         0
     } else {
@@ -28,13 +28,13 @@ fn entry_point(i: usize) -> usize {
 }
 
 /// g(i), the inter sub-hypercube direction.
-fn inter_direction(i: usize) -> u32 {
+const fn inter_direction(i: usize) -> u32 {
     // g(i) counts the trailing set bits in i
     (!i).trailing_zeros()
 }
 
 /// d(i), the intra sub-hypercube direction.
-fn intra_direction(i: usize) -> u32 {
+const fn intra_direction(i: usize) -> u32 {
     if i & 1 != 0 {
         inter_direction(i)
     } else if i > 0 {
@@ -45,7 +45,7 @@ fn intra_direction(i: usize) -> u32 {
 }
 
 /// T transformation inverse
-fn t_inverse(dims: u32, e: usize, d: u32, a: usize) -> usize {
+const fn t_inverse(dims: u32, e: usize, d: u32, a: usize) -> usize {
     rotate_left(a, d, dims) ^ e
 }
 
@@ -136,12 +136,12 @@ pub fn from_compact_hilbert_index(index: usize, bits: &[u32], point: &mut [usize
 }
 
 /// T transformation
-fn t(dims: u32, e: usize, d: u32, b: usize) -> usize {
+const fn t(dims: u32, e: usize, d: u32, b: usize) -> usize {
     rotate_right(b ^ e, d, dims)
 }
 
 /// GrayCodeInverse
-fn gray_code_inverse(mut g: usize) -> usize {
+const fn gray_code_inverse(mut g: usize) -> usize {
     let mut i = 0;
 
     while g != 0 {
@@ -199,8 +199,6 @@ pub fn compact_hilbert_index(bits: &[u32], point: &[usize]) -> usize {
     h
 }
 
-
- 
 /*fn returns_closure (xs: &[u8]) -> impl Fn(u32) -> u32 {
     let sum: u32 = xs.iter().map(|&x| x as u32).sum();
     move |a| a*sum

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub trait Lineariseable<Key> {
 impl<N, const D: usize> Lineariseable<<N as IdealKey<D>>::Key> for [N; D]
 where
     N: IdealKey<D>,
-    N: ToPrimitive + Copy + PrimInt + BitOrAssign + BitAndAssign + core::ops::BitXorAssign,
+    N: ToPrimitive + PrimInt + BitOrAssign + BitAndAssign + core::ops::BitXorAssign,
     <N as IdealKey<D>>::Key:
         PrimInt + From<N> + BitOrAssign + BitAndAssign + ShlAssign<usize> + core::ops::BitXorAssign,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 //! Welcome to `lindel`, the **lin**earisation and **del**inearisation crate! In here you will find functions implementing encoding and decoding operations for Z-indexing and Hilbert indexing, which help linearise data-points while preserving locality.
-//! 
+//!
 //! # Usage
 //! As far as primitive integers are concerned, this crate offers functions that can work either as methods (eg [`x.z_index()`](Lineariseable::z_index())) or as stand-alone functions (eg [`morton_encode(x)`](fn@morton_encode)). All methods are defined within the [`Lineariseable`](trait@Lineariseable) trait.
-//! 
+//!
 //! The program essentially offers two 1-on-1 mappings between arrays and integers; if the array data-type is known, the integer type is selected automatically. For encoding operations, the array data-type is the input, which means that the compiler automatically knows which data-type the output should be. For decoding operations, however, the same integer can be decoded to arrays of different sizes; for that reason, the user will need to signify the output data-type somehow.
-//! 
+//!
 //! Please find illustrating examples below:
-//! 
+//!
 //! ### Z-indexing
 //! ```
 //! # use lindel::*;
@@ -15,17 +15,17 @@
 //! let z_index_2 = input.z_index(); // Method style
 //! assert_eq!(z_index_1, 268447241);
 //! assert_eq!(z_index_1, z_index_2);
-//! 
+//!
 //! let reassembled_input_1: [u8; 4] = morton_decode(z_index_1);
 //! // Output's data-type must be provided by the user
-//! 
+//!
 //! let reassembled_input_2 = <[u8; 4]>::from_z_index(z_index_2);
 //! // Specifying the output data-type with method style is a little more involved.
-//! 
+//!
 //! assert_eq!(input, reassembled_input_1);
 //! assert_eq!(input, reassembled_input_2);
 //! ```
-//! 
+//!
 //! ### Hilbert indexing
 //! ```
 //! # use lindel::*;
@@ -34,7 +34,7 @@
 //! let hilbert_index_2 = input.hilbert_index(); // Method style
 //! assert_eq!(hilbert_index_1, 17414049806762354884);
 //! assert_eq!(hilbert_index_1, hilbert_index_2);
-//! 
+//!
 //! let reassembled_input_1: [u32; 2] = hilbert_decode(hilbert_index_1);
 //! // Output's data-type must be provided by the user
 //!
@@ -44,14 +44,14 @@
 //! assert_eq!(input, reassembled_input_1);
 //! assert_eq!(input, reassembled_input_2);
 //! ```
-//! 
+//!
 //! # Morton encoding (Z-indexing)
 //! This crate re-exports everything from the [`morton_encoding`](morton_encoding) crate for this operation; the user is cordially invited to look there for further information.
-//! 
+//!
 //! # Hilbert encoding
 //! ## Algorithm details
 //! The code for the Hilbert encoding is based on an algorithm by John Skilling, as implemented by Paul Chernoch.
-//! 
+//!
 //! ## Implementation details
 //! Our code is in essence a much-needed refactoring of mr Chernoch's implementation, clarifying the original source code by a lot, leveraging the type-system to help with correctness, and improving the efficiency of the code. To wit:
 //! 1. Instead of accepting arbitrarily-sized slices as input, we accept arrays, to help ensure that each key comes from the encoding of the same amount of dimensions.
@@ -61,18 +61,18 @@
     feature = "nalg",
     doc = "4. Given that the [`nalgebra`](nalgebra) crate exists, we opted to just implement this crate's linearisation methods for its [`Point`](nalgebra::Point) data-types rather than re-implement them as mr Chernoch already did, so as to avail ourselves of its static correctness and sheer performance."
 )]
-//! 
-//! 
+//!
+//!
 //! ## Performance characteristics
 //! Skilling's algorithm has the disadvantage of only examining one bit at a time, but as a result it manages to avoid the very expensive computation of orientation that other algorithms have to perform. We don't know what the theoretical fastest is, if any; this algorithm was selected on an “eh, good enough” basis. We'd like to bench-mark it against other algorithms in the future.
-//! 
+//!
 //! ### Note about leading zeros
 //! In contrast to Morton encoding, Hilbert encoding has the quirk of being dependent on the amount of leading zeros. As a result, because the amount of operations done by Skilling's algorithm is linerarly dependent on the amount of bits examined, it's imperative that one doesn't waste time examining useless bits. It is the solution to this problem that presents a difference between the code we found and the one that ended up in our implementation.
-//! 
+//!
 //! Messrs Skilling and Chernoch solved this problem by taking the amount of bits to be examined as a parametre to the function. This was crucially important to them, because their implementation only accepts `u32`s as its input, which would otherwise mean 32 bits to examine irrespective of the magnitude of the input.
-//! 
+//!
 //! Our solution, on the other hand, can accept coordinates as small as `u8`s. As a result, any data-set which is statically known to contain small enough numbers can simply be modelled with a smaller coordinate data-type, solving the biggest part of this problem in one fell swoop. Nonetheless, we also examine the leading zeros of our coordinates, and skip any leading zeros that come in groups of `D`, where `D` the amount of dimensions; this outputs the exact same results as one would get by examining all bits from the beginning, and allows us to avoid taking the amount of bits as a parametre. Nonetheless, we admittedly haven't benchmarked the cost of zero-counting to compare it to the other costs, because such micro-optimisations were deemed beyond the scope of this crate.
-//! 
+//!
 //! That said, while it is highly improbable that this quirk might come up in production code, it's not entirely impossible! Take, for instance, the following example:
 //! ```rust
 //! # use lindel::*;
@@ -83,18 +83,12 @@
 //! assert_ne!(sample_1.hilbert_index() as u64, sample_2.hilbert_index());
 //! ```
 //! Because the amount of dimensions is not a power of two, adding more bits via a promotion to a larger coordinate data-type inserts leading zeros that end up being taken into account, thereby leading to a different key at the end!
-//! 
+//!
 //! # Nalgebra
-//! Hidden behind the `nalg` feature, so as to avoid dragging unnecessary dependencies to people who don't need them, is the 
-#![cfg_attr(
-    feature = "nalg",
-    doc = "[`nalgebra_points`](nalgebra_points)"
-)]
-#![cfg_attr(
-    not(feature = "nalg"),
-    doc = "`nalgebra_points`"
-)]
-//! module, which offers all of those methods for `Point`s. 
+//! Hidden behind the `nalg` feature, so as to avoid dragging unnecessary dependencies to people who don't need them, is the
+#![cfg_attr(feature = "nalg", doc = "[`nalgebra_points`](nalgebra_points)")]
+#![cfg_attr(not(feature = "nalg"), doc = "`nalgebra_points`")]
+//! module, which offers all of those methods for `Point`s.
 #![cfg_attr(
     feature = "nalg",
     doc = "Please refer there for more information, although there isn't much to be said."
@@ -107,7 +101,7 @@
 //! # Compact Hilbert encoding
 //! Implemented by Chris Hamilton and copied with permission and gratitude into our own code. Information on implementation details and performance characteristics will have to wait until mr Hamilton can explain as much.
 //!
-//! 
+//!
 //!
 //!
 //!
@@ -117,7 +111,7 @@
 #![cfg_attr(all(not(feature = "nalg"), not(test)), no_std)]
 
 pub mod new_uints;
-pub use morton_encoding::{morton_encode, morton_decode, IdealKey, ValidKey};
+pub use morton_encoding::{morton_decode, morton_encode, IdealKey, ValidKey};
 pub mod compact_encoding;
 #[cfg(feature = "nalg")]
 pub mod nalgebra_points;
@@ -127,8 +121,8 @@ use core::ops::BitAndAssign;
 use core::ops::BitOrAssign;
 use core::ops::ShlAssign;
 use num::traits::int::PrimInt;
-use num_traits::ToPrimitive;
 use num::Zero;
+use num_traits::ToPrimitive;
 
 /// General trait for lineariseable data-types. Those are generally arrays, or things that behave like arrays, such as geometric points.
 pub trait Lineariseable<Key> {
@@ -141,48 +135,36 @@ pub trait Lineariseable<Key> {
 impl<N, const D: usize> Lineariseable<<N as IdealKey<D>>::Key> for [N; D]
 where
     N: IdealKey<D>,
-    N: ToPrimitive
-        + Copy
-        + PrimInt
-        + BitOrAssign
-        + BitAndAssign
-        + core::ops::BitXorAssign,
+    N: ToPrimitive + Copy + PrimInt + BitOrAssign + BitAndAssign + core::ops::BitXorAssign,
     <N as IdealKey<D>>::Key:
-        PrimInt 
-        + From<N> 
-        + BitOrAssign 
-        + BitAndAssign 
-        + ShlAssign<usize> 
-        + core::ops::BitXorAssign,
+        PrimInt + From<N> + BitOrAssign + BitAndAssign + ShlAssign<usize> + core::ops::BitXorAssign,
 {
     /// A thin wrapper around the [`morton_encode`](fn@morton_encode) function.
     fn z_index(&self) -> <N as IdealKey<D>>::Key {
         morton_encode(*self)
     }
-    
-    /// A function for creating the Hilbert Index of an array of primitive integers. 
+
+    /// A function for creating the Hilbert Index of an array of primitive integers.
     /// # Examples:
     /// ```
     /// # use lindel::Lineariseable;
     /// assert_eq!([4u8, 5, 6].hilbert_index(), 351);
     /// ```
-    /// 
+    ///
     fn hilbert_index(&self) -> <N as IdealKey<D>>::Key {
-    
         let inverse_gray_encoding = |mut x| -> <N as IdealKey<D>>::Key {
             let log_bits: u32 = (core::mem::size_of::<<N as IdealKey<D>>::Key>() * 8)
                 .next_power_of_two()
                 .trailing_zeros();
-            let powers_of_two = (0..log_bits).map(|i| 1<<i);
+            let powers_of_two = (0..log_bits).map(|i| 1 << i);
             for pow in powers_of_two {
                 x ^= x >> pow
             }
             x
         };
-        
+
         let bits: usize = core::mem::size_of::<N>() * 8;
-        let min_leading_zeros =
-            self.iter().fold(N::zero(), |a, &b| a | b).leading_zeros() as usize;
+        let min_leading_zeros = self.iter().fold(N::zero(), |a, &b| a | b).leading_zeros() as usize;
         if min_leading_zeros == bits {
             return <N as IdealKey<D>>::Key::zero();
         }
@@ -192,7 +174,7 @@ where
         // the total amount of leading zeros, and then re-add
         // the modulo.
 
-        let mut input = self.clone();
+        let mut input = *self;
 
         for single_bit_mask in (1..bits).map(|x| N::one() << x).rev() {
             // We go from most-significant to least-significant bit.
@@ -209,15 +191,15 @@ where
                 first_element ^= less_significant_bit_mask; // invert
             }
             for x_i in input.iter_mut().skip(1) {
-            // For every bit we examine…
+                // For every bit we examine…
                 if current_bit_is_set(*x_i) {
                     first_element ^= less_significant_bit_mask; // invert
-                // If it is set, flip the LSBs of the first element.
+                                                                // If it is set, flip the LSBs of the first element.
                 } else {
                     let t = (first_element ^ *x_i) & less_significant_bit_mask;
                     first_element ^= t;
                     *x_i ^= t;
-                // Otherwise, swap the LSBs of the first element and this one.
+                    // Otherwise, swap the LSBs of the first element and this one.
                 }
             }
             input[0] = first_element;
@@ -230,23 +212,23 @@ where
     fn from_z_index(input: <N as IdealKey<D>>::Key) -> Self {
         morton_decode(input)
     }
-    
-    /// A function for decoding a Hilbert Index into an array of primitive integers. 
+
+    /// A function for decoding a Hilbert Index into an array of primitive integers.
     /// # Examples:
     /// ```
     /// # use lindel::Lineariseable;
     /// assert_eq!(<[u8; 4]>::from_hilbert_index(0xDEADBEEFu32), [199, 38, 136, 240]);
     /// ```
-    /// 
+    ///
     fn from_hilbert_index(input: <N as IdealKey<D>>::Key) -> Self {
         let coor_bits = core::mem::size_of::<N>() * 8;
         let dims = D;
         let mut min_leading_zeros = input.leading_zeros() as usize;
-        
+
         let key_bits = core::mem::size_of::<<N as IdealKey<D>>::Key>() * 8;
         let useless_bits = key_bits - (dims * coor_bits);
         min_leading_zeros -= useless_bits;
-        
+
         min_leading_zeros /= dims;
         // First find the min leading zeros out of all the coordinates…
         let bits = coor_bits + (min_leading_zeros % dims) - min_leading_zeros;
@@ -269,7 +251,7 @@ where
             // We do not need to XOR input[0] with t twice since they cancel each other out.
             let mut first_element = output[0];
             for i in (1..dims).rev() {
-            // For every bit we examine…
+                // For every bit we examine…
                 let x_i = &mut output[i];
                 if current_bit_is_set(*x_i) {
                     first_element ^= less_significant_bit_mask;
@@ -278,7 +260,7 @@ where
                     let t = (first_element ^ *x_i) & less_significant_bit_mask;
                     first_element ^= t;
                     *x_i ^= t;
-                // Otherwise, swap the LSBs of the first element and this one.
+                    // Otherwise, swap the LSBs of the first element and this one.
                 }
             }
             if current_bit_is_set(first_element) {
@@ -288,10 +270,9 @@ where
         }
         output
     }
-    
 }
-    
-/// A free function for decoding a Hilbert Index into an array of primitive integers. 
+
+/// A free function for decoding a Hilbert Index into an array of primitive integers.
 /// # Examples:
 /// ```
 /// # use lindel::hilbert_decode;
@@ -299,26 +280,20 @@ where
 /// // Please note the explicit declaration of the output data type.
 /// assert_eq!(output, [199u8, 38, 136, 240]);
 /// ```
-/// 
+///
 /// Implemented as thin wrapper around the [`from_hilbert_index`](Lineariseable::from_hilbert_index()) method.
 pub fn hilbert_decode<Coordinate, const N: usize>(
     input: <Coordinate as IdealKey<N>>::Key,
 ) -> [Coordinate; N]
 where
-    Coordinate: IdealKey<N> 
-    + ToPrimitive 
-    + PrimInt
-    + BitOrAssign
-    + BitAndAssign
-    + core::ops::BitXorAssign,
-    <Coordinate as IdealKey<N>>::Key: ValidKey<Coordinate>
-    + core::ops::BitXorAssign,
+    Coordinate:
+        IdealKey<N> + ToPrimitive + PrimInt + BitOrAssign + BitAndAssign + core::ops::BitXorAssign,
+    <Coordinate as IdealKey<N>>::Key: ValidKey<Coordinate> + core::ops::BitXorAssign,
 {
     <[Coordinate; N]>::from_hilbert_index(input)
 }
 
-
-/// A free function for creating the Hilbert Index of an array of primitive integers. 
+/// A free function for creating the Hilbert Index of an array of primitive integers.
 /// # Examples:
 /// ```
 /// # use lindel::hilbert_encode;
@@ -330,18 +305,12 @@ pub fn hilbert_encode<Coordinate, const N: usize>(
     input: [Coordinate; N],
 ) -> <Coordinate as IdealKey<N>>::Key
 where
-    Coordinate: IdealKey<N> 
-    + ToPrimitive 
-    + PrimInt
-    + BitOrAssign
-    + BitAndAssign
-    + core::ops::BitXorAssign,
-    <Coordinate as IdealKey<N>>::Key: ValidKey<Coordinate>
-    + core::ops::BitXorAssign,
+    Coordinate:
+        IdealKey<N> + ToPrimitive + PrimInt + BitOrAssign + BitAndAssign + core::ops::BitXorAssign,
+    <Coordinate as IdealKey<N>>::Key: ValidKey<Coordinate> + core::ops::BitXorAssign,
 {
     input.hilbert_index()
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -350,7 +319,7 @@ mod tests {
     const TOTAL_BITS_USED: usize = 10;
     #[cfg(not(debug_assertions))]
     const TOTAL_BITS_USED: usize = 25;
-    
+
     /// This function ought to be capable of checking a Hilbert encoding function as a black box, by solely examining its properties.
     /// Said properties are:
     /// 1. It must be reversible (which also ensures that each key is unique to each array) ("Reversibility")
@@ -363,50 +332,53 @@ mod tests {
 
             fn are_adjacent(x: Set, y: Set) -> bool {
                 fn abs_diff((a, b): (&$coor, &$coor)) -> $coor {
-                    if a > b { a - b } else { b - a }
+                    if a > b {
+                        a - b
+                    } else {
+                        b - a
+                    }
                 }
                 x.iter().zip(y.iter()).map(abs_diff).sum::<$coor>() == 1
             }
-            
+
             const COOR_BITS: usize = core::mem::size_of::<$coor>() * 8;
-        
+
             fn amt_of_bits_differing(x: Set, y: Set) -> usize {
-                let same_bits = x.iter()
+                let same_bits = x
+                    .iter()
                     .zip(y.iter())
-                    .map(|(&a, &b)| a^b)
+                    .map(|(&a, &b)| a ^ b)
                     .map(<$coor>::leading_zeros)
                     .min()
                     .unwrap_or(0) as usize;
                 COOR_BITS - same_bits
             }
-            
-            
+
             if TOTAL_BITS_USED < (COOR_BITS * $dims) {
-                let half_the_bits = TOTAL_BITS_USED>>1;
+                let half_the_bits = TOTAL_BITS_USED >> 1;
                 let rest_of_bits = TOTAL_BITS_USED - half_the_bits;
                 let key_one = 1 as Key;
-                
+
                 let useful_bit_mask: Key = key_one
                     .checked_shl($dims * COOR_BITS as u32)
                     .unwrap_or(0)
                     .wrapping_sub(key_one);
 
-                for _ in 0..(1<<half_the_bits) {
+                for _ in 0..(1 << half_the_bits) {
                     let beginning = rand::random::<Key>() & useful_bit_mask;
                     let first_sample = <[$coor; $dims]>::from_hilbert_index(beginning);
-                    
-                    
-                    let key_iter = (0..(1<<rest_of_bits))
+
+                    let key_iter = (0..(1 << rest_of_bits))
                         .filter_map(|x| beginning.checked_add(x))
-                        .take_while(|&x| x <= useful_bit_mask) 
+                        .take_while(|&x| x <= useful_bit_mask)
                         .map(|x| (x, <[$coor; $dims]>::from_hilbert_index(x)));
                     let key_iter_2 = key_iter.clone().skip(1);
                     let keys_iter = key_iter.zip(key_iter_2);
-                    
+
                     for ((key_1, sample_1), (key_2, sample_2)) in keys_iter {
                         assert_eq!(key_1, sample_1.hilbert_index()); // Reversibility
                         assert!(are_adjacent(sample_1, sample_2)); // Adjacency
-                        
+
                         let diff_bits = amt_of_bits_differing(sample_2, first_sample);
                         if diff_bits < COOR_BITS {
                             let max_difference = (1 as Key) << ($dims * diff_bits);
@@ -420,16 +392,16 @@ mod tests {
                     .checked_shl(COOR_BITS as u32 * $dims)
                     .unwrap_or(0)
                     .wrapping_sub(1);
-                
-                let key_iter = (0..=max_value)
-                    .map(|x| (x, <[$coor; $dims]>::from_hilbert_index(x)));
+
+                let key_iter =
+                    (0..=max_value).map(|x| (x, <[$coor; $dims]>::from_hilbert_index(x)));
                 let key_iter_2 = key_iter.clone().skip(1);
                 let keys_iter = key_iter.zip(key_iter_2);
-                
+
                 for ((key_1, sample_1), (key_2, sample_2)) in keys_iter {
                     assert_eq!(key_1, sample_1.hilbert_index()); // Reversibility
                     assert!(are_adjacent(sample_1, sample_2)); // Adjacency
-                    
+
                     let diff_bits = amt_of_bits_differing(sample_2, [0; $dims]);
                     if diff_bits < COOR_BITS {
                         let max_difference = (1 as Key) << ($dims * diff_bits);
@@ -440,67 +412,67 @@ mod tests {
             }
         };
     }
-    
+
     #[test]
     fn u8_2d() {
         check_vals!(u8, 2);
     }
-    
+
     #[test]
     fn u8_3d() {
         check_vals!(u8, 3);
     }
-    
+
     #[test]
     fn u8_4d() {
         check_vals!(u8, 4);
     }
-    
+
     #[test]
     fn u8_5d() {
         check_vals!(u8, 5);
     }
-    
+
     #[test]
     fn u8_6d() {
         check_vals!(u8, 6);
     }
-    
+
     #[test]
     fn u8_7d() {
         check_vals!(u8, 7);
     }
-    
+
     #[test]
     fn u8_8d() {
         check_vals!(u8, 8);
     }
-    
+
     #[test]
     fn u16_2d() {
         check_vals!(u16, 2);
     }
-    
+
     #[test]
     fn u16_3d() {
         check_vals!(u16, 3);
     }
-    
+
     #[test]
     fn u16_4d() {
         check_vals!(u16, 4);
     }
-    
+
     #[test]
     fn u32_3d() {
         check_vals!(u32, 3);
     }
-    
+
     #[test]
     fn u32_4d() {
         check_vals!(u32, 4);
     }
-    
+
     #[test]
     fn u64_2d() {
         check_vals!(u64, 2);

--- a/src/nalgebra_points.rs
+++ b/src/nalgebra_points.rs
@@ -296,7 +296,7 @@ mod tests {
     macro_rules! check_vals {
         ($coor: ty, $dims: ty) => {
             type Set = Point<$coor, $dims>;
-            type Key = Self;
+            type Key = <$coor as IdealKey<$dims>>::Key;
 
             fn are_adjacent(x: Set, y: Set) -> bool {
                 fn abs_diff((a, b): (&$coor, &$coor)) -> $coor {

--- a/src/nalgebra_points.rs
+++ b/src/nalgebra_points.rs
@@ -1,16 +1,15 @@
 //! A few traits and functions for linearising `nalgebra`'s `Point` data-types.
-//! 
+//!
 //! For people who've understood the functions in the main library, there's absolutely nothing new here. The only difference is that, rather than implementing each function in both method and function ways, each function is only implemented method-style (for the encoding) or associated-function style (for the decoding). Please refer to the examples mentioned in the [`Lineariseable`](Lineariseable) trait or the `README` file.
-use morton_encoding::{bloat_custom_checked, shrink_custom_checked, nz};
+use morton_encoding::{bloat_custom_checked, nz, shrink_custom_checked};
 use nalgebra::*;
-use std::ops::{BitAndAssign, BitOrAssign, ShlAssign};
 use num::PrimInt;
 use num_traits::Zero;
-
+use std::ops::{BitAndAssign, BitOrAssign, ShlAssign};
 
 /// Given a data type and a type-number, it yields the smallest unsigned
 /// integer that's at least `N` times larger.
-/// 
+///
 /// Implemented by brute force.
 
 pub trait IdealKey<N> {
@@ -19,101 +18,101 @@ pub trait IdealKey<N> {
 
 // UGLY WORK-AROUND, HOOOOOOOO!
 impl IdealKey<U1> for u8 {
-    type Key = u8;
+    type Key = Self;
 }
 impl IdealKey<U2> for u8 {
-    type Key = u16;
+    type Key = Self;
 }
 impl IdealKey<U3> for u8 {
-    type Key = u32;
+    type Key = Self;
 }
 impl IdealKey<U4> for u8 {
-    type Key = u32;
+    type Key = Self;
 }
 impl IdealKey<U5> for u8 {
-    type Key = u64;
+    type Key = Self;
 }
 impl IdealKey<U6> for u8 {
-    type Key = u64;
+    type Key = Self;
 }
 impl IdealKey<U7> for u8 {
-    type Key = u64;
+    type Key = Self;
 }
 impl IdealKey<U8> for u8 {
-    type Key = u64;
+    type Key = Self;
 }
 impl IdealKey<U9> for u8 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U10> for u8 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U11> for u8 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U12> for u8 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U13> for u8 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U14> for u8 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U15> for u8 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U16> for u8 {
-    type Key = u128;
+    type Key = Self;
 }
 
 impl IdealKey<U1> for u16 {
-    type Key = u16;
+    type Key = Self;
 }
 impl IdealKey<U2> for u16 {
-    type Key = u32;
+    type Key = Self;
 }
 impl IdealKey<U3> for u16 {
-    type Key = u64;
+    type Key = Self;
 }
 impl IdealKey<U4> for u16 {
-    type Key = u64;
+    type Key = Self;
 }
 impl IdealKey<U5> for u16 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U6> for u16 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U7> for u16 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U8> for u16 {
-    type Key = u128;
+    type Key = Self;
 }
 
 impl IdealKey<U1> for u32 {
-    type Key = u32;
+    type Key = Self;
 }
 impl IdealKey<U2> for u32 {
-    type Key = u64;
+    type Key = Self;
 }
 impl IdealKey<U3> for u32 {
-    type Key = u128;
+    type Key = Self;
 }
 impl IdealKey<U4> for u32 {
-    type Key = u128;
+    type Key = Self;
 }
 
 impl IdealKey<U1> for u64 {
-    type Key = u64;
+    type Key = Self;
 }
 impl IdealKey<U2> for u64 {
-    type Key = u128;
+    type Key = Self;
 }
 
 impl IdealKey<U1> for u128 {
-    type Key = u128;
+    type Key = Self;
 }
 
 use super::Lineariseable;
@@ -130,12 +129,7 @@ where
         + BitAndAssign
         + std::ops::BitXorAssign,
     <N as IdealKey<D>>::Key:
-        PrimInt 
-        + From<N> 
-        + BitOrAssign 
-        + BitAndAssign 
-        + ShlAssign<usize> 
-        + std::ops::BitXorAssign,
+        PrimInt + From<N> + BitOrAssign + BitAndAssign + ShlAssign<usize> + std::ops::BitXorAssign,
     DefaultAllocator: nalgebra::allocator::Allocator<N, D>,
 {
     /// The 'Point' analogue for the primitive types' [`z_index`](Lineariseable::z_index) method.
@@ -153,7 +147,7 @@ where
             })
             .fold(<N as IdealKey<D>>::Key::zero(), |acc, x| (acc << 1) | x)
     }
-    
+
     /// The 'Point' analogue for the primitive types' [`hilbert_index`](Lineariseable::hilbert_index) method.
     /// # Examples
     /// ```rust
@@ -162,18 +156,17 @@ where
     /// assert_eq!(pnt.hilbert_index(), 4961111386034627444566496746);
     /// ```
     fn hilbert_index(&self) -> <N as IdealKey<D>>::Key {
-    
         let inverse_gray_encoding = |mut x| -> <N as IdealKey<D>>::Key {
             let log_bits: u32 = (std::mem::size_of::<<N as IdealKey<D>>::Key>() * 8)
                 .next_power_of_two()
                 .trailing_zeros();
-            let powers_of_two = (0..log_bits).map(|i| 1<<i);
+            let powers_of_two = (0..log_bits).map(|i| 1 << i);
             for pow in powers_of_two {
                 x ^= x >> pow
             }
             x
         };
-        
+
         let bits: usize = std::mem::size_of::<N>() * 8;
         let mut min_leading_zeros =
             self.iter().fold(N::zero(), |a, &b| a | b).leading_zeros() as usize;
@@ -213,8 +206,7 @@ where
 
         inverse_gray_encoding(input.z_index())
     }
-    
-    
+
     /// The 'Point' analogue for the primitive types' [`z_index`](Lineariseable::from_z_index) method.
     /// # Examples
     /// ```rust
@@ -237,8 +229,7 @@ where
         }
         result
     }
-    
-    
+
     /// The 'Point' analogue for the primitive types' [`hilbert_index`](Lineariseable::from_hilbert_index) method.
     /// # Examples
     /// ```rust
@@ -253,11 +244,11 @@ where
         let coor_bits = std::mem::size_of::<N>() * 8;
         let dims = <D as DimName>::dim();
         let mut min_leading_zeros = input.leading_zeros() as usize;
-        
+
         let key_bits = std::mem::size_of::<<N as IdealKey<D>>::Key>() * 8;
         let useless_bits = key_bits - (dims * coor_bits);
         min_leading_zeros -= useless_bits;
-        
+
         min_leading_zeros /= dims;
         min_leading_zeros /= dims;
         min_leading_zeros *= dims;
@@ -294,7 +285,6 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,27 +292,31 @@ mod tests {
     const TOTAL_BITS_USED: usize = 10;
     #[cfg(not(debug_assertions))]
     const TOTAL_BITS_USED: usize = 19;
-    
+
     macro_rules! check_vals {
         ($coor: ty, $dims: ty) => {
             type Set = Point<$coor, $dims>;
-            type Key = <$coor as IdealKey<$dims>>::Key;
+            type Key = Self;
 
             fn are_adjacent(x: Set, y: Set) -> bool {
                 fn abs_diff((a, b): (&$coor, &$coor)) -> $coor {
-                    if a > b { a - b } else { b - a }
+                    if a > b {
+                        a - b
+                    } else {
+                        b - a
+                    }
                 }
                 x.iter().zip(y.iter()).map(abs_diff).sum::<$coor>() == 1
             }
-            
+
             let coor_bits = std::mem::size_of::<$coor>() * 8;
             let dims = <$dims as DimName>::dim();
             let useful_bits = (dims * coor_bits) as u32;
-            
+
             let big_limit = (1 as Key)
                 .checked_shl(TOTAL_BITS_USED as u32)
                 .unwrap_or(Key::MAX);
-            
+
             use rand::Rng;
             let creation = Set::from_hilbert_index;
             let mut rng = rand::thread_rng();
@@ -333,83 +327,82 @@ mod tests {
             let beginning = rng.gen_range(0..limit);
             let test_this = (0..big_limit)
                 .map(|x| x + beginning)
-                .map(|x| (creation(x), creation(x+1)));
+                .map(|x| (creation(x), creation(x + 1)));
 
             for (a, b) in test_this {
-
                 let thing_1 = a.z_index();
                 let thing_2 = Set::from_z_index(thing_1);
                 assert_eq!(a, thing_2);
-                
+
                 let thing_1 = a.hilbert_index();
                 let thing_2 = Set::from_hilbert_index(thing_1);
                 assert_eq!(a, thing_2);
-                
+
                 assert!(are_adjacent(a, b));
             }
         };
     }
-    
+
     #[test]
     fn u8_2d() {
         check_vals!(u8, U2);
     }
-    
+
     #[test]
     fn u8_3d() {
         check_vals!(u8, U3);
     }
-    
+
     #[test]
     fn u8_4d() {
         check_vals!(u8, U4);
     }
-    
+
     #[test]
     fn u8_5d() {
         check_vals!(u8, U5);
     }
-    
+
     #[test]
     fn u8_6d() {
         check_vals!(u8, U6);
     }
-    
+
     #[test]
     fn u8_7d() {
         check_vals!(u8, U7);
     }
-    
+
     #[test]
     fn u8_8d() {
         check_vals!(u8, U8);
     }
-    
+
     #[test]
     fn u16_2d() {
         check_vals!(u16, U2);
     }
-    
+
     #[test]
     fn u16_3d() {
         check_vals!(u16, U3);
     }
-    
+
     #[test]
     fn u16_4d() {
         check_vals!(u16, U4);
     }
-    
+
     #[test]
     fn u32_3d() {
         check_vals!(u32, U3);
     }
-    
+
     #[test]
     fn u32_4d() {
         check_vals!(u32, U4);
     }
-    
+
     #[test]
     fn u64_2d() {
         check_vals!(u64, U2);

--- a/src/new_uints.rs
+++ b/src/new_uints.rs
@@ -1,12 +1,12 @@
 //! A macro that creates a new `[usize; N]` data-type that behaves as an integer for the purposes of accepting a new `Key`.
-//! 
+//!
 //! The `create_lineariseable_data_type` macro accepts three arguments:
 //! 1. The coordinate data-type, an unsigned integer
 //! 2. The amount of dimensions that the data-set must have
 //! 3. A name for the new data-type that will function as the key. (Must be provided by the user.)
-//! 
+//!
 //! We haven't yet tried whether it can accept the new data-types it output as input coordinates; `u128`s were considered enough as a limit.
-//! 
+//!
 //! # Example usage:
 //! ```rust
 //! lindel::create_lineariseable_data_type!(u128, 33, NewKey);
@@ -18,7 +18,7 @@
 //! let reinstated_input = NewKey::from_z_index(zind);
 //! assert_eq!(input, reinstated_input);
 //! ```
-//! 
+//!
 //! # Note
 //! Please bear in mind that the new data-type has only implemented whichever methods and operators were strictly necessary for its operation as a Key; for instance, only wrapping addition is implemented, and subtraction is lacking entirely.
 #[macro_export]
@@ -132,11 +132,12 @@ macro_rules! create_lineariseable_data_type {
                     Ok((x.0[0] & mask).try_into().unwrap())
                 } else {
                     let mut result: $coor = 0usize.try_into().unwrap();
-                    let amt_of_usizes_in_a_coor = ($key::COOR_BYTES + $key::USIZE_BYTES - 1) / $key::USIZE_BYTES;
+                    let amt_of_usizes_in_a_coor =
+                        ($key::COOR_BYTES + $key::USIZE_BYTES - 1) / $key::USIZE_BYTES;
                     for &a in x.0.iter().take(amt_of_usizes_in_a_coor).rev() {
-                            result = result.wrapping_shl($key::USIZE_BITS.try_into().unwrap());
-                            let a: $coor = a.try_into().unwrap();
-                            result |= a;
+                        result = result.wrapping_shl($key::USIZE_BITS.try_into().unwrap());
+                        let a: $coor = a.try_into().unwrap();
+                        result |= a;
                     }
                     Ok(result)
                 }
@@ -456,7 +457,7 @@ macro_rules! create_lineariseable_data_type {
                 result
             }
         }
-    }
+    };
 }
 
 #[cfg(test)]
@@ -465,17 +466,20 @@ mod tests {
     const TOTAL_BITS_USED: usize = 10;
     #[cfg(not(debug_assertions))]
     const TOTAL_BITS_USED: usize = 19;
-    
+
     macro_rules! check_vals {
         ($coor: ty, $dims: expr) => {
             create_lineariseable_data_type!($coor, $dims, Keyyy);
             type Set = [$coor; $dims];
-            
-            fn get_random_key () -> Keyyy {
+
+            fn get_random_key() -> Keyyy {
                 let mut result: Keyyy = 0usize.into();
-                result.0.iter_mut().for_each(|x| *x = rand::random::<usize>());
+                result
+                    .0
+                    .iter_mut()
+                    .for_each(|x| *x = rand::random::<usize>());
                 let remaining_bytes = ($dims * Keyyy::COOR_BYTES) % Keyyy::USIZE_BYTES;
-                let mask: usize = 1<<(remaining_bytes*8);
+                let mask: usize = 1 << (remaining_bytes * 8);
                 let mask = mask - 1;
                 result.0.iter_mut().rev().take(1).for_each(|a| (*a) &= mask);
                 result
@@ -483,92 +487,97 @@ mod tests {
 
             fn are_adjacent(x: Set, y: Set) -> bool {
                 fn abs_diff((a, b): (&$coor, &$coor)) -> $coor {
-                    if a > b { a - b } else { b - a }
+                    if a > b {
+                        a - b
+                    } else {
+                        b - a
+                    }
                 }
                 x.iter().zip(y.iter()).map(abs_diff).sum::<$coor>() == 1
             }
-            
+
             let big_limit = 1usize << TOTAL_BITS_USED;
             let beginning = get_random_key();
 
             for i in 0..big_limit {
-                
                 let a = beginning + i.into();
-                let b = beginning + (i+1).into();
-                
-                if b > beginning {break;}
-                
+                let b = beginning + (i + 1).into();
+
+                if b > beginning {
+                    break;
+                }
+
                 let a = Keyyy::from_hilbert_index(a);
                 let b = Keyyy::from_hilbert_index(b);
-                
+
                 let thing_1 = Keyyy::z_index(a);
                 let thing_2 = Keyyy::from_z_index(thing_1);
                 assert_eq!(a, thing_2);
-                
+
                 let thing_1 = Keyyy::hilbert_index(a);
                 let thing_2 = Keyyy::from_hilbert_index(thing_1);
                 assert_eq!(a, thing_2);
-                
+
                 assert!(are_adjacent(a, b));
             }
         };
     }
-    
+
     #[test]
     fn u8_17d() {
         check_vals!(u8, 17);
     }
-    
+
     #[test]
     fn u8_18d() {
         check_vals!(u8, 18);
     }
-    
+
     #[test]
     fn u8_19d() {
         check_vals!(u8, 19);
     }
-    
+
     #[test]
     fn u8_20d() {
         check_vals!(u8, 20);
     }
-    
+
     #[test]
     fn u16_9d() {
         check_vals!(u16, 9);
     }
-    
+
     #[test]
     fn u16_10d() {
         check_vals!(u16, 10);
     }
-    
+
     #[test]
     fn u16_11d() {
         check_vals!(u16, 11);
     }
-    
+
     #[test]
     fn u32_5d() {
         check_vals!(u32, 5);
     }
-    
+
     #[test]
     fn u32_6d() {
         check_vals!(u32, 6);
     }
-    
+
     #[test]
     fn u32_7d() {
         check_vals!(u32, 7);
     }
-    
+
     #[test]
     fn u64_3d() {
         check_vals!(u64, 3);
     }
-    
+
     #[test]
     fn u64_5d() {
         check_vals!(u64, 5);

--- a/src/new_uints.rs
+++ b/src/new_uints.rs
@@ -418,7 +418,7 @@ macro_rules! create_lineariseable_data_type {
                 for single_bit_mask in (1..bits).map(|i| coor_one << i) {
                     // We go from LSB to MSB
 
-                    let current_bit_is_set = |x: $coor| x & single_bit_mask != 0u8.into();
+                    let current_bit_is_set = |x: $coor| x & single_bit_mask != 0;
 
                     let less_significant_bit_mask: $coor = single_bit_mask - coor_one;
 


### PR DESCRIPTION
Benchmark references in a intel macos (2.3 GHz Intel Core i9 8-Core, 2 GB 2667 MHz DDR4):

```sh
Benchmarking hilbert_decode: Collecting 100 samples in estimated 5.0013 s (12M ihilbert_decode          time:   [419.09 ns 421.19 ns 423.64 ns]
Found 15 outliers among 100 measurements (15.00%)
  8 (8.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

Benchmarking hilbert_encode: Collecting 100 samples in estimated 5.0024 s (9.5M hilbert_encode          time:   [521.55 ns 524.41 ns 528.68 ns]
Found 15 outliers among 100 measurements (15.00%)
  9 (9.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

Benchmarking morton_decode: Collecting 100 samples in estimated 5.0017 s (12M itmorton_decode           time:   [403.47 ns 404.51 ns 405.62 ns]
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low severe
  7 (7.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

Benchmarking morton_encode: Collecting 100 samples in estimated 5.0020 s (10M itmorton_encode           time:   [490.83 ns 492.14 ns 493.49 ns]
Found 16 outliers among 100 measurements (16.00%)
  8 (8.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
```

Commit [217de14](https://github.com/DoubleHyphen/lindel/pull/8/commits/217de148bff5f49af5505ec400ccd0808c825aca) seems to reduce this values in ~2.5% by removing the Copy trait bound.